### PR TITLE
fix: replace deprecated add_event_handler with lifespan context manager

### DIFF
--- a/src/kohakuriver/host/app.py
+++ b/src/kohakuriver/host/app.py
@@ -14,6 +14,7 @@ Responsibilities:
 
 import asyncio
 import os
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Path, Query, WebSocket
 
@@ -52,11 +53,19 @@ logger = get_logger(__name__)
 # Background tasks tracking
 background_tasks: set[asyncio.Task] = set()
 
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await startup_event()
+    yield
+    await shutdown_event()
+
+
 # FastAPI application instance
 app = FastAPI(
     title="HakuRiver Host",
     description="Cluster management host server",
     version="0.4.0",
+    lifespan=lifespan,
 )
 
 # Include API routers (all under /api prefix)
@@ -192,9 +201,6 @@ async def shutdown_event():
     logger.info("Host server shut down complete")
 
 
-# Register lifecycle handlers
-app.add_event_handler("startup", startup_event)
-app.add_event_handler("shutdown", shutdown_event)
 
 
 # =============================================================================

--- a/src/kohakuriver/runner/app.py
+++ b/src/kohakuriver/runner/app.py
@@ -7,6 +7,7 @@ Main entry point for the runner server.
 import asyncio
 import os
 import socket
+from contextlib import asynccontextmanager
 
 import docker as docker_lib
 import httpx
@@ -46,11 +47,19 @@ background_tasks: set[asyncio.Task] = set()
 numa_topology: dict | None = None
 task_store: TaskStateStore | None = None
 
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    await startup_event()
+    yield
+    await shutdown_event()
+
+
 # FastAPI app
 app = FastAPI(
     title="HakuRiver Runner",
     description="Cluster runner node",
     version="0.2.0",
+    lifespan=lifespan,
 )
 
 # Include routers (all under /api prefix)
@@ -463,8 +472,6 @@ async def shutdown_event():
             )
 
 
-app.add_event_handler("startup", startup_event)
-app.add_event_handler("shutdown", shutdown_event)
 
 
 def run():


### PR DESCRIPTION
## Summary
- Replace `add_event_handler("startup"/​"shutdown")` with FastAPI `lifespan` context manager in host and runner apps
- Fixes startup crash: `'FastAPI' object has no attribute 'add_event_handler'`

## Reason
`add_event_handler` was removed in newer versions of FastAPI/Starlette. `lifespan` is the official replacement.
<img width="1750" height="108" alt="image" src="https://github.com/user-attachments/assets/b6b361c4-8201-4f09-89ae-0c1765f15183" />