### PR TITLE
fix: add preflight check for native extension compatibility

### DIFF
--- a/src/kohakuriver/cli/host.py
+++ b/src/kohakuriver/cli/host.py
@@ -81,6 +81,15 @@ def run(
             f"Using built-in defaults. Run 'kohakuriver init config --host' to generate config."
         )
 
+    # Pre-flight: verify native extensions load on this CPU
+    from kohakuriver.utils.preflight import check_native_extensions
+
+    try:
+        check_native_extensions()
+    except RuntimeError as e:
+        print(f"ERROR: {e}")
+        raise typer.Exit(1)
+
     # Run the server
     try:
         print("Starting KohakuRiver Host server...")

--- a/src/kohakuriver/cli/runner.py
+++ b/src/kohakuriver/cli/runner.py
@@ -81,6 +81,15 @@ def run(
             f"Using built-in defaults. Run 'kohakuriver init config --runner' to generate config."
         )
 
+    # Pre-flight: verify native extensions load on this CPU
+    from kohakuriver.utils.preflight import check_native_extensions
+
+    try:
+        check_native_extensions()
+    except RuntimeError as e:
+        print(f"ERROR: {e}")
+        raise typer.Exit(1)
+
     # Run the server
     try:
         print("Starting KohakuRiver Runner agent...")

--- a/src/kohakuriver/utils/preflight.py
+++ b/src/kohakuriver/utils/preflight.py
@@ -1,0 +1,53 @@
+"""
+Pre-flight checks for KohakuRiver startup.
+
+Validates system requirements before importing heavy native extensions
+that would otherwise crash silently (e.g. SIGILL from unsupported CPU
+instructions).
+"""
+
+
+def check_native_extensions() -> None:
+    """Verify that native extensions can load on this CPU.
+
+    kohakuvault ships a C extension that may be compiled with AVX/AVX2.
+    On CPUs without AVX support, importing it triggers SIGILL and kills
+    the process silently — no Python exception, no log output.
+
+    This function tests the import in a subprocess so the main process
+    survives, and raises a clear RuntimeError on failure.
+    """
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import kohakuvault"],
+        capture_output=True,
+        timeout=10,
+    )
+
+    if result.returncode != 0:
+        sig = -result.returncode if result.returncode < 0 else result.returncode
+        hints = []
+
+        # exit code 132 = 128 + 4 (SIGILL), also check raw signal number
+        if result.returncode in (-4, 132):
+            hints.append(
+                "This usually means kohakuvault was compiled with CPU instructions "
+                "(e.g. AVX2) that this machine does not support."
+            )
+            hints.append(
+                "Fix: reinstall from source with\n"
+                "  uv pip install --no-binary kohakuvault --force-reinstall kohakuvault"
+            )
+
+        msg = (
+            f"Failed to load kohakuvault native extension "
+            f"(exit code {result.returncode})."
+        )
+        if result.stderr:
+            msg += f"\nstderr: {result.stderr.decode(errors='replace').strip()}"
+        if hints:
+            msg += "\n" + "\n".join(hints)
+
+        raise RuntimeError(msg)


### PR DESCRIPTION
## Summary

- Runner/Host exits silently with no error output when kohakuvault's C extension is compiled with CPU instructions (e.g. AVX2) unsupported by the host machine
- Root cause: SIGILL is an OS-level signal that kills the process before Python's try/except can catch anything
- Add a subprocess-based preflight check that tests `import kohakuvault` in a child process before the main import, showing a clear error message and fix command on failure

## Context

On CPUs that only support SSE (no AVX/AVX2), `import kohakuvault` triggers SIGILL (exit code 132 = 128 + SIGILL). The kernel terminates the process immediately. From the user's perspective, the program prints "Starting KohakuRiver Runner agent..." then silently returns to the shell prompt with zero diagnostic output.


## Origin
<img width="1666" height="240" alt="image" src="https://github.com/user-attachments/assets/915cb160-059b-4f51-bbdd-b244d8c99115" />

## Add Preflight
<img width="853" height="279" alt="螢幕擷取畫面 2026-04-13 115058" src="https://github.com/user-attachments/assets/c124e695-8438-4f58-ba09-fdb8dd1dcc81" />